### PR TITLE
Added step attribute on target bg range

### DIFF
--- a/views/reportindex.html
+++ b/views/reportindex.html
@@ -91,9 +91,9 @@
       <tr>
         <td colspan="2">
           <span class="translate">Target bg range bottom</span>:
-          <input type="number" size="3" id="rp_targetlow">
+          <input type="number" size="3" step="0.1" id="rp_targetlow">
           <span class="translate">top</span>:
-          <input type="number" size="3" id="rp_targethigh">
+          <input type="number" size="3" step="0.1" id="rp_targethigh">
         </td>
         <td></td>
       </tr>


### PR DESCRIPTION
Added step attribute on target bg range numeric textboxes so users in mmol/L can enter decimals without the browser complaining or completely eating the number.